### PR TITLE
Directories with spaces fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,13 +18,13 @@ function askdialog(config) {
     cmd = path.join(cmd, 'windows', filename + '.exe')
   }
   if (config.type === 'directory')
-    cmd += ' -d';
+    cmd += '" -d';
   else if (config.type === 'save-file')
-    cmd += ' -s';
+    cmd += '" -s';
   else if (config.type === 'open-file')
-    cmd += ' -o';
+    cmd += '" -o';
   else if (config.type === 'open-files')
-    cmd += ' -f';
+    cmd += '" -f';
   var promise = new Promise((resolve, reject) => {
     exec(path.join(root, cmd), (error, stdout, stderr) => {
       if (stdout) {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function askdialog(config) {
   else if (config.type === 'open-files')
     cmd += '" -f';
   var promise = new Promise((resolve, reject) => {
-    exec(path.join(root, cmd), (error, stdout, stderr) => {
+    exec('"' + path.join(root, cmd), (error, stdout, stderr) => {
       if (stdout) {
         if (stdout.trim() === 'None')
           reject(new Error('Nothing selected'));


### PR DESCRIPTION
Currently on windows you get an error when selecting directories with spaces in the name. This fixes it by adding "" around it.