### PR TITLE
fix: Declaration file not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.3",
   "description": "Shows a gui dialog box to choose files/folders on server side",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
- Added type linking in package.json to resolve the error 'node-file-dialog' declaration file not found. ISSUES CLOSED: #14